### PR TITLE
Only handle top-level expressions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var acorn = require('acorn')
-var walk = require('walk-ast')
+var walk = require('estree-walker').walk
 var MagicString = require('magic-string')
 
 function optimizeJs (jsString, opts) {
@@ -9,13 +9,13 @@ function optimizeJs (jsString, opts) {
   var ast = acorn.parse(jsString)
   var magicString = new MagicString(jsString)
 
-  function walkIt (node) {
+  function walkIt (node, parentNode) {
     if (node.type === 'FunctionExpression') {
-      handleFunctionExpression(node)
+      handleFunctionExpression(node, parentNode)
     }
   }
 
-  function handleFunctionExpression (node) {
+  function handleFunctionExpression (node, parentNode) {
     var prePreChar = jsString.charAt(node.start - 2)
     var preChar = jsString.charAt(node.start - 1)
     var postChar = jsString.charAt(node.end)
@@ -24,12 +24,12 @@ function optimizeJs (jsString, opts) {
     // assuming this node is an argument to a function, return true if it itself
     // is already padded with parentheses
     function isPaddedArgument (node) {
-      var idx = node.parentNode.arguments.indexOf(node)
+      var idx = parentNode.arguments.indexOf(node)
       if (idx === 0) { // first arg
         if (prePreChar === '(' && preChar === '(' && postChar === ')') { // already padded
           return true
         }
-      } else if (idx === node.parentNode.arguments.length - 1) { // last arg
+      } else if (idx === parentNode.arguments.length - 1) { // last arg
         if (preChar === '(' && postChar === ')' && postPostChar === ')') { // already padded
           return true
         }
@@ -41,19 +41,19 @@ function optimizeJs (jsString, opts) {
       return false
     }
 
-    if (node.parentNode && node.parentNode.type === 'CallExpression') {
+    if (parentNode && parentNode.type === 'CallExpression') {
       // this function is getting called itself or
       // it is getting passed in to another call expression
       // the else statement is strictly never hit, but I think the code is easier to read this way
       /* istanbul ignore else */
-      if (node.parentNode.arguments.length && node.parentNode.arguments.indexOf(node) !== -1) {
+      if (parentNode.arguments.length && parentNode.arguments.indexOf(node) !== -1) {
         // function passed in to another function. these are almost _always_ executed, e.g.
         // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.
         if (!isPaddedArgument(node)) { // don't double-pad
           magicString = magicString.insertLeft(node.start, '(')
             .insertRight(node.end, ')')
         }
-      } else if (node.parentNode.callee === node) {
+      } else if (parentNode.callee === node) {
         // this function is getting immediately invoked, e.g. function(){}()
         if (preChar !== '(') {
           magicString.insertLeft(node.start, '(')
@@ -63,7 +63,7 @@ function optimizeJs (jsString, opts) {
     }
   }
 
-  walk(ast, walkIt)
+  walk(ast, { enter: walkIt })
   var out = magicString.toString()
   if (opts.sourceMap) {
     out += '\n//# sourceMappingURL=' + magicString.generateMap().toUrl()

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,11 @@ function optimizeJs (jsString, opts) {
   var magicString = new MagicString(jsString)
 
   function walkIt (node, parentNode) {
-    if (node.type === 'FunctionExpression') {
-      handleFunctionExpression(node, parentNode)
+    if (/Function/.test(node.type)) {
+      if (node.type === 'FunctionExpression') {
+        handleFunctionExpression(node, parentNode)
+      }
+      this.skip() // don't descend any further
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "acorn": "^3.3.0",
     "concat-stream": "^1.5.1",
+    "estree-walker": "^0.2.1",
     "magic-string": "^0.16.0",
-    "walk-ast": "^0.0.2",
     "yargs": "^4.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is more for discussion than anything – I couldn't spend long on it so no tests yet, sorry!

@stefanpenner has been doing some research on this topic and found that the lazy parse heuristic only applies at the top level. I wondered if we could exploit that here and avoid having to walk the entire AST. As a bonus, we'd save a few bytes on parens that would (in theory) have no effect.

To do so I swapped out `walk-ast` for `estree-walker` (full disclosure, it's one of mine) which makes it possible to skip subgraphs. We get a little speed bump just from doing that, because `estree-walker` doesn't mutate the AST in any way (i.e. adding the `parentNode` property), but the real boost is from doing less work. (It would also fix #3.)

Example results:

```bash
➜  optimize-js git:(master) time lib/bin.js benchmarks/ember.js > /dev/null
lib/bin.js benchmarks/ember.js > /dev/null  0.65s user 0.08s system 106% cpu 0.689 total
➜  optimize-js git:(master) git checkout speedup
Switched to branch 'speedup'
Your branch is up-to-date with 'origin/speedup'.
➜  optimize-js git:(speedup) time lib/bin.js benchmarks/ember.js > /dev/null
lib/bin.js benchmarks/ember.js > /dev/null  0.47s user 0.05s system 117% cpu 0.437 total
```

So optimisation is ~25% quicker in Ember's case with this PR.

I ran the benchmarks on Chrome, and the improvement went from 55.75% to 53.62%. So it looks like there's a *slight* drop in parse time but I don't know if it's significant. More investigation needed probably!