### PR TITLE
Don't call process.exit(0) on success.

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -25,7 +25,6 @@ inStream.pipe(concat(function (buf) {
   try {
     var out = optimizeJs(str, opts)
     console.log(out)
-    process.exit(0)
   } catch (err) {
     console.error(err)
     process.exit(1)


### PR DESCRIPTION
This causes commands like `optimize-js large-file.js` to not output the full output to stdout.

To repro:
```
$ curl -O https://code.jquery.com/jquery-3.0.0.min.js
$ optimize-js jquery-3.0.0.min.js  | wc
// 3     982   65536
$ optimize-js jquery-3.0.0.min.js > foo.js
$ cat foo.js | wc
//  5    1312   86638
```