### PR TITLE
Fix for #7: Not as optimized for Webpack as it could be. 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,15 +21,16 @@ function optimizeJs (jsString, opts) {
     var postChar = jsString.charAt(node.end)
     var postPostChar = jsString.charAt(node.end + 1)
 
-    // assuming this node is an argument to a function, return true if it itself
-    // is already padded with parentheses
+    // assuming this node is an argument to a function or an element in an array,
+    // return true if it itself is already padded with parentheses
     function isPaddedArgument (node) {
-      var idx = node.parentNode.arguments.indexOf(node)
+      var parentArray = node.parentNode.arguments ? node.parentNode.arguments : node.parentNode.elements
+      var idx = parentArray.indexOf(node)
       if (idx === 0) { // first arg
         if (prePreChar === '(' && preChar === '(' && postChar === ')') { // already padded
           return true
         }
-      } else if (idx === node.parentNode.arguments.length - 1) { // last arg
+      } else if (idx === parentArray.length - 1) { // last arg
         if (preChar === '(' && postChar === ')' && postPostChar === ')') { // already padded
           return true
         }
@@ -41,24 +42,48 @@ function optimizeJs (jsString, opts) {
       return false
     }
 
-    if (node.parentNode && node.parentNode.type === 'CallExpression') {
-      // this function is getting called itself or
-      // it is getting passed in to another call expression
-      // the else statement is strictly never hit, but I think the code is easier to read this way
-      /* istanbul ignore else */
-      if (node.parentNode.arguments.length && node.parentNode.arguments.indexOf(node) !== -1) {
-        // function passed in to another function. these are almost _always_ executed, e.g.
-        // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.
-        if (!isPaddedArgument(node)) { // don't double-pad
-          magicString = magicString.insertLeft(node.start, '(')
-            .insertRight(node.end, ')')
-        }
-      } else if (node.parentNode.callee === node) {
-        // this function is getting immediately invoked, e.g. function(){}()
-        if (preChar !== '(') {
-          magicString.insertLeft(node.start, '(')
-            .insertRight(node.end, ')')
-        }
+    function isCallExpression (node) {
+      return node && node.type === 'CallExpression'
+    }
+
+    function isArrayExpression (node) {
+      return node && node.type === 'ArrayExpression'
+    }
+
+    // returns true iff node is an argument to a function call expression.
+    function isArgumentToFunctionCall (node) {
+      return isCallExpression(node.parentNode) &&
+        node.parentNode.arguments.length &&
+        node.parentNode.arguments.indexOf(node) !== -1
+    }
+
+    // returns true iff node is an element of an array literal which is in turn
+    // an argument to a function call expression.
+    function isElementOfArrayArgumentToFunctionCall (node) {
+      return isArrayExpression(node.parentNode) &&
+        node.parentNode.elements.indexOf(node) !== -1 &&
+        isArgumentToFunctionCall(node.parentNode)
+    }
+
+    // returns true iff node is an IIFE.
+    function isIIFE (node) {
+      return isCallExpression(node.parentNode) &&
+        node.parentNode.callee === node
+    }
+
+    if (isArgumentToFunctionCall(node) || isElementOfArrayArgumentToFunctionCall(node)) {
+      // function passed in to another function, either as an argument, or as an element
+      // of an array argument. these are almost _always_ executed, e.g. webpack bundles,
+      // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.
+      if (!isPaddedArgument(node)) { // don't double-pad
+        magicString = magicString.insertLeft(node.start, '(')
+          .insertRight(node.end, ')')
+      }
+    } else if (isIIFE(node)) {
+      // this function is getting immediately invoked, e.g. function(){}()
+      if (preChar !== '(') {
+        magicString.insertLeft(node.start, '(')
+          .insertRight(node.end, ')')
       }
     }
   }

--- a/test/cases/array-literal-iife-in-function-scope/input.js
+++ b/test/cases/array-literal-iife-in-function-scope/input.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    !function() {return 1;}()
+  ];
+}

--- a/test/cases/array-literal-iife-in-function-scope/output.js
+++ b/test/cases/array-literal-iife-in-function-scope/output.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    !(function() {return 1;})()
+  ];
+}

--- a/test/cases/array-literal-iife-in-global-scope/input.js
+++ b/test/cases/array-literal-iife-in-global-scope/input.js
@@ -1,0 +1,3 @@
+var a = [
+  !function() {return 1;}()
+]

--- a/test/cases/array-literal-iife-in-global-scope/output.js
+++ b/test/cases/array-literal-iife-in-global-scope/output.js
@@ -1,0 +1,3 @@
+var a = [
+  !(function() {return 1;})()
+]

--- a/test/cases/array-literal-in-function-scope/input.js
+++ b/test/cases/array-literal-in-function-scope/input.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    function() {return 1;}
+  ];
+}

--- a/test/cases/array-literal-in-function-scope/output.js
+++ b/test/cases/array-literal-in-function-scope/output.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    function() {return 1;}
+  ];
+}

--- a/test/cases/array-literal-in-global-scope/input.js
+++ b/test/cases/array-literal-in-global-scope/input.js
@@ -1,0 +1,3 @@
+var a = [
+  function() {return 1;}
+]

--- a/test/cases/array-literal-in-global-scope/output.js
+++ b/test/cases/array-literal-in-global-scope/output.js
@@ -1,0 +1,3 @@
+var a = [
+  function() {return 1;}
+]

--- a/test/cases/webpack-style-multi-element/input.js
+++ b/test/cases/webpack-style-multi-element/input.js
@@ -1,0 +1,9 @@
+!function(o){
+  return o[0]();
+}([function(o,r,t){
+  console.log("webpack style element 0");
+},function(o,r,t){
+  console.log("webpack style element 1");
+},function(o,r,t){
+  console.log("webpack style element 2");
+}]);

--- a/test/cases/webpack-style-multi-element/output.js
+++ b/test/cases/webpack-style-multi-element/output.js
@@ -1,0 +1,9 @@
+!(function(o){
+  return o[0]();
+})([(function(o,r,t){
+  console.log("webpack style element 0");
+}),(function(o,r,t){
+  console.log("webpack style element 1");
+}),(function(o,r,t){
+  console.log("webpack style element 2");
+})]);

--- a/test/cases/webpack-style-one-element/input.js
+++ b/test/cases/webpack-style-one-element/input.js
@@ -1,0 +1,5 @@
+!function(o){
+  return o[0]();
+}([function(o,r,t){
+  console.log("webpack style!");
+}]);

--- a/test/cases/webpack-style-one-element/output.js
+++ b/test/cases/webpack-style-one-element/output.js
@@ -1,0 +1,5 @@
+!(function(o){
+  return o[0]();
+})([(function(o,r,t){
+  console.log("webpack style!");
+})]);


### PR DESCRIPTION
Adds ability to wrap functions that are elements of an array literal in an argument list.

I refactored some of the if-else logic into named functions that were easier for me to understand, but I'm not sure if they will be easier for others or not. Feedback welcome.

`npm run test` runs green and `npm run coverage` gives 100%.

Running on the benchmark repo from The Cost of Small Modules on my MBP (and snipping out non-webpack versions for space), I get:

Chrome  54.0.2840.71

```
100 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,2.51,1.55,4.06
webpack-optimized,2.88,0.26,3.14
1000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,7.33,16.92,24.25
webpack-optimized,9.4,1.65,11.05
5000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,35.44,47.64,83.09
webpack-optimized,44.72,6.25,50.97
```

Firefox 48.0.2

```
100 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,2.07,0.93,3
webpack-optimized,2.29,0.45,2.74
1000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,5.28,6.18,11.45
webpack-optimized,8.5,1.63,10.13
5000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,22.03,29.4,51.43
webpack-optimized,36.4,7.36,43.76
```

Safari 9.1.3

```
100 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,2.19,0.39,2.58
webpack-optimized,2.16,0.38,2.54
1000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,3.34,1.52,4.86
webpack-optimized,2.69,1.69,4.38
5000 modules,,,
Bundler,Load time (ms),Run time (ms),Total time (ms)
webpack,6.97,9.71,16.67
webpack-optimized,6.19,8.26,14.45
```

Thanks for all your work!
