### PR TITLE
Webpack-specific fix for issue #7

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,19 @@ function optimizeJs (jsString, opts) {
         node.parentNode.callee === node
     }
 
-    if (isArgumentToFunctionCall(node) || isElementOfArrayArgumentToFunctionCall(node)) {
+    // tries to divine if this function is a webpack module wrapper.
+    // returns true iff node is an element of an array literal which is in turn
+    // an argument to a function call expression, and that function call
+    // expression is an IIFE.
+    function isProbablyWebpackModule (node) {
+      return isElementOfArrayArgumentToFunctionCall(node) &&
+        node.parentNode && // array literal
+        node.parentNode.parentNode && // CallExpression
+        node.parentNode.parentNode.callee && // function that is being called
+        node.parentNode.parentNode.callee.type === 'FunctionExpression'
+    }
+
+    if (isArgumentToFunctionCall(node) || isProbablyWebpackModule(node)) {
       // function passed in to another function, either as an argument, or as an element
       // of an array argument. these are almost _always_ executed, e.g. webpack bundles,
       // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,15 +21,16 @@ function optimizeJs (jsString, opts) {
     var postChar = jsString.charAt(node.end)
     var postPostChar = jsString.charAt(node.end + 1)
 
-    // assuming this node is an argument to a function, return true if it itself
-    // is already padded with parentheses
+    // assuming this node is an argument to a function or an element in an array,
+    // return true if it itself is already padded with parentheses
     function isPaddedArgument (node) {
-      var idx = node.parentNode.arguments.indexOf(node)
+      var parentArray = node.parentNode.arguments ? node.parentNode.arguments : node.parentNode.elements
+      var idx = parentArray.indexOf(node)
       if (idx === 0) { // first arg
         if (prePreChar === '(' && preChar === '(' && postChar === ')') { // already padded
           return true
         }
-      } else if (idx === node.parentNode.arguments.length - 1) { // last arg
+      } else if (idx === parentArray.length - 1) { // last arg
         if (preChar === '(' && postChar === ')' && postPostChar === ')') { // already padded
           return true
         }
@@ -41,24 +42,48 @@ function optimizeJs (jsString, opts) {
       return false
     }
 
-    if (node.parentNode && node.parentNode.type === 'CallExpression') {
-      // this function is getting called itself or
-      // it is getting passed in to another call expression
-      // the else statement is strictly never hit, but I think the code is easier to read this way
-      /* istanbul ignore else */
-      if (node.parentNode.arguments.length && node.parentNode.arguments.indexOf(node) !== -1) {
-        // function passed in to another function. these are almost _always_ executed, e.g.
-        // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.
-        if (!isPaddedArgument(node)) { // don't double-pad
-          magicString = magicString.insertLeft(node.start, '(')
-            .insertRight(node.end, ')')
-        }
-      } else if (node.parentNode.callee === node) {
-        // this function is getting immediately invoked, e.g. function(){}()
-        if (preChar !== '(') {
-          magicString.insertLeft(node.start, '(')
-            .insertRight(node.end, ')')
-        }
+    function isCallExpression (node) {
+      return node && node.type === 'CallExpression'
+    }
+
+    function isArrayExpression (node) {
+      return node && node.type === 'ArrayExpression'
+    }
+
+    // returns true iff node is an argument to a function call expression.
+    function isArgumentToFunctionCall (node) {
+      return isCallExpression(node.parentNode) &&
+        node.parentNode.arguments.length &&
+        node.parentNode.arguments.indexOf(node) !== -1
+    }
+
+    // returns true iff node is an element of an array literal which is in turn
+    // an argument to a function call expression.
+    function isElementOfArrayArgumentToFunctionCall (node) {
+      return isArrayExpression(node.parentNode) &&
+        node.parentNode.elements.indexOf(node) !== -1 &&
+        isArgumentToFunctionCall(node.parentNode)
+    }
+
+    // returns true iff node is an IIFE.
+    function isIIFE (node) {
+      return isCallExpression(node.parentNode) &&
+        node.parentNode.callee === node
+    }
+
+    if (isArgumentToFunctionCall(node) || isElementOfArrayArgumentToFunctionCall(node)) {
+      // function passed in to another function, either as an argument, or as an element
+      // of an array argument. these are almost _always_ executed, e.g. webpack bundles,
+      // UMD bundles, Browserify bundles, Node-style errbacks, Promise then()s and catch()s, etc.
+      if (!isPaddedArgument(node)) { // don't double-pad
+        magicString = magicString.insertLeft(node.start, '(')
+          .insertRight(node.end, ')')
+      }
+    } else if (isIIFE(node)) {
+      // this function is getting immediately invoked, e.g. function(){}()
+      if (preChar !== '(') {
+        magicString.insertLeft(node.start, '(')
+          .insertRight(node.end, ')')
       }
     }
   }

--- a/test/cases/array-literal-iife-in-function-scope/input.js
+++ b/test/cases/array-literal-iife-in-function-scope/input.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    !function() {return 1;}()
+  ];
+}

--- a/test/cases/array-literal-iife-in-function-scope/output.js
+++ b/test/cases/array-literal-iife-in-function-scope/output.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    !(function() {return 1;})()
+  ];
+}

--- a/test/cases/array-literal-iife-in-global-scope/input.js
+++ b/test/cases/array-literal-iife-in-global-scope/input.js
@@ -1,0 +1,3 @@
+var a = [
+  !function() {return 1;}()
+]

--- a/test/cases/array-literal-iife-in-global-scope/output.js
+++ b/test/cases/array-literal-iife-in-global-scope/output.js
@@ -1,0 +1,3 @@
+var a = [
+  !(function() {return 1;})()
+]

--- a/test/cases/array-literal-in-function-params/input.js
+++ b/test/cases/array-literal-in-function-params/input.js
@@ -1,0 +1,5 @@
+foo([
+  function(o,r,t){
+    console.log("element 0");
+  }
+]);

--- a/test/cases/array-literal-in-function-params/output.js
+++ b/test/cases/array-literal-in-function-params/output.js
@@ -1,0 +1,5 @@
+foo([
+  function(o,r,t){
+    console.log("element 0");
+  }
+]);

--- a/test/cases/array-literal-in-function-scope/input.js
+++ b/test/cases/array-literal-in-function-scope/input.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    function() {return 1;}
+  ];
+}

--- a/test/cases/array-literal-in-function-scope/output.js
+++ b/test/cases/array-literal-in-function-scope/output.js
@@ -1,0 +1,5 @@
+function b() {
+  var a = [
+    function() {return 1;}
+  ];
+}

--- a/test/cases/array-literal-in-global-scope/input.js
+++ b/test/cases/array-literal-in-global-scope/input.js
@@ -1,0 +1,3 @@
+var a = [
+  function() {return 1;}
+]

--- a/test/cases/array-literal-in-global-scope/output.js
+++ b/test/cases/array-literal-in-global-scope/output.js
@@ -1,0 +1,3 @@
+var a = [
+  function() {return 1;}
+]

--- a/test/cases/webpack-style-multi-element/input.js
+++ b/test/cases/webpack-style-multi-element/input.js
@@ -1,0 +1,9 @@
+!function(o){
+  return o[0]();
+}([function(o,r,t){
+  console.log("webpack style element 0");
+},function(o,r,t){
+  console.log("webpack style element 1");
+},function(o,r,t){
+  console.log("webpack style element 2");
+}]);

--- a/test/cases/webpack-style-multi-element/output.js
+++ b/test/cases/webpack-style-multi-element/output.js
@@ -1,0 +1,9 @@
+!(function(o){
+  return o[0]();
+})([(function(o,r,t){
+  console.log("webpack style element 0");
+}),(function(o,r,t){
+  console.log("webpack style element 1");
+}),(function(o,r,t){
+  console.log("webpack style element 2");
+})]);

--- a/test/cases/webpack-style-one-element/input.js
+++ b/test/cases/webpack-style-one-element/input.js
@@ -1,0 +1,5 @@
+!function(o){
+  return o[0]();
+}([function(o,r,t){
+  console.log("webpack style!");
+}]);

--- a/test/cases/webpack-style-one-element/output.js
+++ b/test/cases/webpack-style-one-element/output.js
@@ -1,0 +1,5 @@
+!(function(o){
+  return o[0]();
+})([(function(o,r,t){
+  console.log("webpack style!");
+})]);


### PR DESCRIPTION
This is a more webpack-specific fix for issue #7 than the solution presented in PR #28. Rather than optimize every function expression that is an element of an array literal param, this PR only optimizes function expressions that are elements of an array literal param **of a function expression call**.

So, unlike PR #28, this PR will **not** transform this code:

```
foo([
  function(o,r,t){
    console.log("element 0");
  }
]);
```

because `foo` is not a function expression.

I think that this version is probably better than PR #28, but I'm happy to hear dissenting views!
