### PR TITLE
Fixed a microbug that added optimized benchmark libs to the test suite.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ var assert = require('assert')
 var testCases = fs.readdirSync('test/cases')
 var benchmarkLibs = fs.readdirSync('benchmarks').filter(function (script) {
   return script.indexOf('.min') === -1 &&
-    script.indexOf('.optimized' === -1) &&
+    script.indexOf('.optimized') === -1 &&
     script.indexOf('.js') !== -1
 })
 


### PR DESCRIPTION
In master, the test suite adds the `.optimized.js` benchmarks (if they exist) as test cases because of what I'm pretty sure is a misplaced parenthesis.